### PR TITLE
implemented atomic behavior support

### DIFF
--- a/brood/__init__.py
+++ b/brood/__init__.py
@@ -1,6 +1,6 @@
 from aiomas import expose, run
 from .world import World
-from .agent import Agent
+from .agent import Agent, behavior
 from .simulation import Simulation
 from .node import Node, Cluster
 from . import distributors, world, handlers

--- a/brood/agent/__init__.py
+++ b/brood/agent/__init__.py
@@ -1,0 +1,2 @@
+from .base import Agent
+from .behavior import behavior

--- a/brood/agent/behavior.py
+++ b/brood/agent/behavior.py
@@ -1,0 +1,18 @@
+from functools import wraps
+
+
+def behavior(*required_vars):
+    """decorator to declare an agent behavior
+    and its required state variables.
+    when an Agent class is created, presence of
+    required variables is validated.
+    behaviors should not modify state variables directly!
+    they should only _submit_ updates to be applied during the update phase."""
+    def decorator(f):
+        f.required_vars = list(required_vars)
+        @wraps(f)
+        def func(agent, *args, **kwargs):
+            return f(agent, *args, **kwargs)
+        return func
+    return decorator
+

--- a/brood/cli.py
+++ b/brood/cli.py
@@ -83,9 +83,7 @@ def start_node(port):
     """start a node"""
     task = Node.start(('0.0.0.0', port),
                       codec=aiomas.codecs.MsgPackBlosc,
-                      extra_serializers=[
-                          serializers.get_np_serializer,
-                          serializers.get_state_serializer])
+                      extra_serializers=[serializers.get_np_serializer])
 
     # terminates when the node's manager is given the 'stop' command
     aiomas.run(until=task)

--- a/brood/node/cluster.py
+++ b/brood/node/cluster.py
@@ -2,7 +2,7 @@ import re
 import aiomas
 import asyncio
 import paramiko
-from .serializers import get_np_serializer, get_state_serializer
+from .serializers import get_np_serializer
 from ..distributors import RoundRobin
 
 
@@ -25,9 +25,7 @@ class Cluster:
                          for host, user, start_port in hosts), [])
         self._container = aiomas.Container.create(('localhost', port),
                                                   codec=aiomas.codecs.MsgPackBlosc,
-                                                  extra_serializers=[
-                                                      get_np_serializer,
-                                                      get_state_serializer])
+                                                  extra_serializers=[get_np_serializer])
         self._container.has_manager = True
         self._managers = aiomas.run(self._connect_to_managers(self.hosts))
         self._distributor = distributor(self._managers)

--- a/brood/node/serializers.py
+++ b/brood/node/serializers.py
@@ -1,5 +1,4 @@
 import numpy as np
-from brood.agent import State
 
 
 # from: <https://aiomas.readthedocs.io/en/latest/guides/codecs.html>
@@ -20,15 +19,3 @@ def _serialize_ndarray(obj):
 def _deserialize_ndarray(obj):
    array = np.fromstring(obj['data'], dtype=np.dtype(obj['type']))
    return array.reshape(obj['shape'])
-
-
-def get_state_serializer():
-    return State, _serialize_state, _deserialize_state
-
-
-def _serialize_state(obj):
-    return obj.__dict__
-
-
-def _deserialize_state(obj):
-    return State(**obj)


### PR DESCRIPTION
Adds capability for atomic behaviors (i.e. a component pattern, as used in games) for agents.

Behaviors can be defined independently:

```python
import brood

@brood.behavior('stress')
def hard_work(agent):
    self.submit_var_update('stress', 100)

@brood.behavior('hunger')
def eat_food(agent):
    self.submit_var_update('hunger', 0)
```

The `brood.behavior` decorator declares which state variables the behavior requires.

Then agents can be defined using these behaviors (as a more flexible alternative to subclassing):

```python
class Person(brood.Agent):
    state_vars = ['stress', 'hunger']
    behaviors = [hard_work, eat_food]
```

These behaviors will automatically be called when the agent's `decide` method is called.

If we define an agent missing any state variables required by its behaviors, a `MissingVarError` will be raised.



